### PR TITLE
Updated documentation with examples of using secrets and date_label

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -2,22 +2,22 @@ Use this drone plugin to upgrade a k8s deployment
 
 The following parameters are used to configure this plugin:
 
-- `url` - url to your cluster server
+- `url` - Url to your cluster server
 - `token` - Token used to connect to the cluster
-- `cert` - cert to connect to cluster //Not implemented
-- `insecure` - allow for insecure cluster connection //Not verified
-- `deployment_names` - name(s) of the deployment to update
-- `container_names` - container(s) name in the deployment to update
-- `namespaces` - namespace(s) (will use default if not set)  
-- `docker_image` - new image to assign to container in the deployment, including tag (`drone/drone:latest`)
-- `date_label` - label where the date of the deployment took place. Nice to use if using latest to deploy images
+- `cert` - Cert to connect to cluster //Not implemented
+- `insecure` - Allow for insecure cluster connection //Not verified
+- `deployment_names` - Name(s) of the deployment to update
+- `container_names` - Container(s) name in the deployment to update
+- `namespaces` - Namespace(s) (will use default if not set)  
+- `docker_image` - New image to assign to container in the deployment, including tag (`drone/drone:latest`)
+- `date_label` - Label where the date of the deployment took place. Use it when you want to force container upgrading, even if you docker image tag has not changed.
 
 
 The following is a sample k8s deployment configuration in your `.drone.yml` file:
 
 ```yaml
-deploy:
-  k8s-deployment:
+pipeline:
+  deploy:
     image: peloton/drone-k8s-deployment
     url: https://k8s.server/
     token: asldkfj
@@ -31,8 +31,8 @@ deploy:
 Or with multiples
 
 ```yaml
-deploy:
-  k8s-deployment:
+pipeline:
+  deploy:
     image: peloton/drone-k8s-deployment
     url: https://k8s.server/
     token: asldkfj
@@ -45,4 +45,35 @@ deploy:
 
 It's not recommended to update multiples of namespaces, deployment_names, and conatiner_names.  Try to keep things simple.
 
-if you want to add secrets for the token it's KUBERNETES_TOKEN
+If you want to add secrets for the token or url use KUBERNETES_TOKEN, KUBERNETES_URL
+
+```yaml
+pipeline:
+  deploy:
+    image: peloton/drone-k8s-deployment
+    token: asldkfj
+    insecure: false
+    deployment_names: [mything, mything2]
+    container_names: mything
+    namespaces: [mynamespace, anothernamspace]
+    docker_image: drone/drone:latest
+    secrets: [kubernetes_url, kubernetes_token]
+```
+
+If you want to force docker container upgrading, there is a hack which allows you to do this even if your image name/tag has not changed. Put to the data_label key ENV variable from Drone CI with a timestamp, such as this:
+
+```yaml
+pipeline:
+  deploy:
+    image: peloton/drone-k8s-deployment
+    token: asldkfj
+    insecure: false
+    deployment_names: [mything, mything2]
+    container_names: mything
+    namespaces: [mynamespace, anothernamspace]
+    docker_image: drone/drone:latest
+    date_label: "${DRONE_BUILD_FINISHED}"
+    secrets: [kubernetes_url, kubernetes_token]
+```
+
+The list of available Drone CI env variables you could find [here](http://docs.drone.io/environment-reference/)

--- a/DOCS.md
+++ b/DOCS.md
@@ -10,7 +10,7 @@ The following parameters are used to configure this plugin:
 - `container_names` - Container(s) name in the deployment to update
 - `namespaces` - Namespace(s) (will use default if not set)  
 - `docker_image` - New image to assign to container in the deployment, including tag (`drone/drone:latest`)
-- `date_label` - Label where the date of the deployment took place. Use it when you want to force container upgrading, even if you docker image tag has not changed.
+- `date_label` - Label where the date of the deployment took place. Use it when you want to force container upgrading, even if your docker image tag has not changed.
 
 
 The following is a sample k8s deployment configuration in your `.drone.yml` file:
@@ -60,7 +60,7 @@ pipeline:
     secrets: [kubernetes_url, kubernetes_token]
 ```
 
-If you want to force docker container upgrading, there is a hack which allows you to do this even if your image name/tag has not changed. Put to the data_label key ENV variable from Drone CI with a timestamp, such as this:
+If you want to force docker container upgrading, there is a hack which allows you to do this even if your image name/tag has not changed. Put to the data_label the text such as `deployment.drone.io/date-deployed`(could be any name you want) and it will be used for defining annotation with timestamp for Kubernetes deployment:
 
 ```yaml
 pipeline:
@@ -72,8 +72,7 @@ pipeline:
     container_names: mything
     namespaces: [mynamespace, anothernamspace]
     docker_image: drone/drone:latest
-    date_label: "${DRONE_BUILD_FINISHED}"
+    date_label: deployment.drone.io/date-deployed
     secrets: [kubernetes_url, kubernetes_token]
 ```
 
-The list of available Drone CI env variables you could find [here](http://docs.drone.io/environment-reference/)


### PR DESCRIPTION
Hi, based on the discussions at https://github.com/josmo/drone-k8s-deployment/issues/2 
I changed a little bit existing documentation of the plugin, added example with using secrets and date_label.